### PR TITLE
Feat/replace apostrophes

### DIFF
--- a/rules/spell-checker.js
+++ b/rules/spell-checker.js
@@ -161,7 +161,7 @@ module.exports = {
             if(!hasToSkip(value)) {
                 // Regular expression matches regexp metacharacters, and any special char
                 var regexp = /(\\[sSwdDB0nfrtv])|\\[0-7][0-7][0-7]|\\x[0-9A-F][0-9A-F]|\\u[0-9A-F][0-9A-F][0-9A-F][0-9A-F]|[^0-9a-zA-Z ']/g,
-                    nodeWords = value.replace(/ʼ/g, '\'').replace(regexp, ' ')
+                    nodeWords = value.replace(/’/g, '\'').replace(regexp, ' ')
                         .replace(/([A-Z])/g, ' $1').split(' '),
                     errors;
                 errors = nodeWords

--- a/rules/spell-checker.js
+++ b/rules/spell-checker.js
@@ -161,7 +161,7 @@ module.exports = {
             if(!hasToSkip(value)) {
                 // Regular expression matches regexp metacharacters, and any special char
                 var regexp = /(\\[sSwdDB0nfrtv])|\\[0-7][0-7][0-7]|\\x[0-9A-F][0-9A-F]|\\u[0-9A-F][0-9A-F][0-9A-F][0-9A-F]|[^0-9a-zA-Z ']/g,
-                    nodeWords = value.replace(regexp, ' ')
+                    nodeWords = value.replace(/ʼ/g, '\'').replace(regexp, ' ')
                         .replace(/([A-Z])/g, ' $1').split(' '),
                     errors;
                 errors = nodeWords


### PR DESCRIPTION
`checkSpelling` will now replace curly apostrophes with straight ones so that words with curly apostrophes can be spell-checked.